### PR TITLE
removing uvloop from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -112,7 +112,6 @@ typing_extensions==4.12.2
 ujson==5.10.0
 urllib3==2.2.2
 uvicorn==0.30.1
-uvloop==0.19.0
 vosk==0.3.44
 watchfiles==0.22.0
 websocket-client==1.8.0


### PR DESCRIPTION
Proposed means of addressing #17 - uvloop was added to requirements but does not appear to be necessary for the PhilBott to run.

Holding this for a couple days pending feedback from issue reporter.  Will merge 25 Aug if no response.